### PR TITLE
Add compatibility with CRMSH 2.3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,8 @@ Currently, it supports crm configure sub commands below:
 - property (tested)
 - rsc_defaults
 - fencing_topology
+
+compatibility
+-------------
+
+This version has been tested with crmsh 2.2.x and 2.3.x.

--- a/pacemaker
+++ b/pacemaker
@@ -85,7 +85,11 @@ class BaseParser(object):
             self.module = module
         if self.crmsh:
             debug.append("crmsh prim: %s" % args[0])
-            clip = crmsh.parse.CliParser()
+            # See https://github.com/ClusterLabs/crmsh/commit/5b11db312101b2b798017fef9e7539fd5fb8585a
+            if hasattr(crmsh.parse,'CliParser'):
+                clip = crmsh.parse.CliParser()
+            else:
+                clip = crmsh.parse
             self.cib = clip.parse(' '.join(args))
             self.command = args[0]
             self.id = self.cib.get('id')


### PR DESCRIPTION
They removed CliParser, see https://github.com/ClusterLabs/crmsh/commit/5b11db312101b2b798017fef9e7539fd5fb8585a for details.
I modified the code to check the existence of CliParser.